### PR TITLE
Add --version / -v flag (closes #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gorilla/mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MCP server for Gorilla. Find your first SaaS users on Reddit, X, YouTube, and TikTok. https://usegorilla.app",
   "private": false,
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,22 @@
 #!/usr/bin/env node
 /// <reference types="node" />
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+
+// --version / -v: print the package version and exit. Saves users from
+// piping into the stdio loop just to find out which version they have.
+const argv = process.argv.slice(2);
+if (argv.includes("--version") || argv.includes("-v")) {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8")) as { version: string };
+  console.log(pkg.version);
+  process.exit(0);
+}
 
 // ---------------------------------------------------------------------------
 // Configuration


### PR DESCRIPTION
Closes #8.

The bug-report issue template tells users to run `npx -y github:opusforge/gorilla-mcp --version` to figure out which version they're on. The server didn't actually handle the flag.

## Change
- `src/index.ts`: small preamble that checks `process.argv` for `--version` or `-v`. If present, reads the version from the shipped `package.json` and prints it before constructing the MCP server.
- `package.json`: bumped from 1.0.0 to 1.0.1 to match the v1.0.1 tag we cut earlier.

## Verified
```
$ node dist/index.js --version
1.0.1
$ node dist/index.js -v
1.0.1
```

Server still runs normally without the flag (verified via stdio init handshake).