### PR TITLE
refactor: replace chained source formatting with scalable formatter map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gorilla/mcp",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gorilla/mcp",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,7 @@ function formatPost(p: Post): string {
   const ch =
     p.source === "reddit"
       ? `r/${p.channel.name}`
-      : p.source === "twitter"
+      : ["twitter", "x", "instagram", "tiktok"].includes(p.source)
         ? `@${p.channel.name}`
         : `${p.source}/${p.channel.name}`;
 


### PR DESCRIPTION
Previously, only Twitter posts used the @handle format, which caused Instagram and TikTok posts to fallback to the ugly source/handle format in the outreach drafts. Expanded the check to properly format handles for X, Instagram, and TikTok.

Earlier it was like this 
<img width="382" height="204" alt="Screenshot 2026-04-30 at 00 50 50" src="https://github.com/user-attachments/assets/7a9442db-19b9-453f-a79b-5009bb25f6f0" />

Now I fixed it
<img width="491" height="160" alt="Screenshot 2026-04-30 at 00 51 48" src="https://github.com/user-attachments/assets/55137563-3b20-4e38-acbd-ddae61797254" />

